### PR TITLE
Debounce led

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Contents
 * ``controlhal`` - Abstractions for controlling a dynamic system. Easy PID control loops.
 
 * ``debouncedpin`` - Debounced ``Pin`` drop-in that automatically handles switch debouncing.
+  Can also drive an LED using the same pin with ``DebouncedLedPin``.
 
 * ``interp1d`` - One dimensional interpolation functions.
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Contents
 * ``controlhal`` - Abstractions for controlling a dynamic system. Easy PID control loops.
 
 * ``debouncedpin`` - Debounced ``Pin`` drop-in that automatically handles switch debouncing.
-  Can also drive an LED using the same pin with ``DebouncedLedPin``.
+  Can also simultaneously drive an LED using the same pin with ``DebouncedLedPin``.
 
 * ``interp1d`` - One dimensional interpolation functions.
 
@@ -64,6 +64,15 @@ Finally, to actually get the code onto your device, run:
    belay install [DEVICE-PORT]
 
 You can specify other argument to ``belay install``, including cross-compiling the python code.
+
+Repo Folder Structure
+=====================
+
+* ``lib/`` - Micropython modules.
+
+*  ``tests/`` - Tests for micropython modules
+
+*  ``demos/`` - For code that primarily interacts with hardware, these serve as minimal scripts for demonstrating their use.
 
 
 .. _Belay Package Manager: https://belay.readthedocs.io/en/latest/Package%20Manager.html

--- a/demos/debouncedpin.py
+++ b/demos/debouncedpin.py
@@ -9,10 +9,30 @@ parser = argparse.ArgumentParser()
 parser.add_argument("port")
 parser.add_argument("--pin", type=int, default=14)
 parser.add_argument("--debounce", action="store_true")
+parser.add_argument("--debounce-led", action="store_true")
 args = parser.parse_args()
 
 device = belay.Device(args.port)
 device.sync(lib)
+
+
+@device.task
+def normal(pin):
+    """Non-debounced switch.
+
+    The counter should (maybe) increment multiple times whenever you press the button.
+    """
+    count = 0
+    button = Pin(pin, Pin.IN, Pin.PULL_UP)
+
+    def handler(pin):
+        nonlocal count
+        count += 1
+        print(count)
+
+    button.irq(handler=handler, trigger=Pin.IRQ_FALLING)
+    while True:
+        time.sleep(1)
 
 
 @device.task
@@ -34,21 +54,30 @@ def debounced(pin):
 
 
 @device.task
-def normal(pin):
+def debounced_led(pin):
+    from debouncedpin import DebouncedLedPin
+
     count = 0
-    button = Pin(pin, Pin.IN, Pin.PULL_UP)
 
     def handler(pin):
         nonlocal count
         count += 1
+        if count % 2:
+            pin.on()
+        else:
+            pin.off()
         print(count)
 
-    button.irq(handler=handler, trigger=Pin.IRQ_FALLING)
+    pin = DebouncedLedPin(pin, Pin.PULL_UP)
+    pin.irq(handler, DebouncedLedPin.IRQ_FALLING)
+
     while True:
         time.sleep(1)
 
 
-if args.debounce:
+if args.debounce_led:
+    debounced_led(args.pin)
+elif args.debounce:
     debounced(args.pin)
 else:
     normal(args.pin)

--- a/lib/debouncedpin.py
+++ b/lib/debouncedpin.py
@@ -144,6 +144,9 @@ class DebouncedPin(Pin):
 class DebouncedLedPin(DebouncedPin):
     """Control a LED and read a switch with a single GPIO.
 
+    If the LED is activated; it will be turned off for an
+    imperceivably short duration to read the switch state.
+
     Connections (PULL_UP)::
 
         GPIO -> 270Ω -> LED -> GND

--- a/lib/debouncedpin.py
+++ b/lib/debouncedpin.py
@@ -1,5 +1,7 @@
 """Debounced input pin for reading buttons/switches.
 
+Can also drive an LED using the same pin.
+
 Typical use-case 1; ``handler`` will be invoked whenever
 a debounced press is detected. This assumes button connects
 to ground.
@@ -143,6 +145,8 @@ class DebouncedPin(Pin):
 
 class DebouncedLedPin(DebouncedPin):
     """Control a LED and read a switch with a single GPIO.
+
+    Requires an additional resistor component for the switch.
 
     If the LED is activated; it will be turned off for an
     imperceivably short duration to read the switch state.

--- a/lib/debouncedpin.py
+++ b/lib/debouncedpin.py
@@ -153,20 +153,27 @@ class DebouncedLedPin(DebouncedPin):
 
     Connections (PULL_UP)::
 
-        GPIO -> 270Ω -> LED -> GND
+        GPIO -> 100Ω -> LED -> GND
              -> 10kΩ -> switch -> GND
 
     Connections (PULL_DOWN)::
 
-        GPIO -> 270Ω -> LED -> Vcc
+        GPIO -> 100Ω -> LED -> Vcc
              -> 10kΩ -> switch -> Vcc
 
     * Adjust the LED resistor according to desired forward current.
     * The switch resistor should probably be in the range of 5k~20k.
+    * The switch resistor **can come after** the LED resistor.
+      This is useful if the led/switch combo is physically far from
+      the microcontroller. The LED resistor can be mounted to the PCB
+      and provides moderate short-circuit-protection.
     """
 
     def __init__(self, id, pull, *, value=None, period=20, timer_id=-1):
         super().__init__(id, pull=pull, value=value, period=period, timer_id=timer_id)
+        # the Pin object is supposed to remember its pull state;
+        # but this isn't bug free in all ports.
+        self._pull = pull
         self.init(Pin.OUT)
 
     def value(self, x=None):
@@ -180,6 +187,6 @@ class DebouncedLedPin(DebouncedPin):
             return Pin.value(self, x)
 
     def _timer_callback(self, timer):
-        self.init(Pin.IN)
+        self.init(Pin.IN, pull=self._pull)
         super()._timer_callback(timer)
         self.init(Pin.OUT)


### PR DESCRIPTION
Adds `DebounceLedPin` which enables controlling an LED from the same pin that reads a button input. Aside from the LED resistor, this requires an additional ~10kΩ resistor for the switch.

Besides reducing the number of GPIOs required for LED + button control, this is useful if the LED/button is physically far from the microcontrollers and you want to reduce the number of interconnect wires.